### PR TITLE
Fix Tornado Dragon game crashes

### DIFF
--- a/DuelistMod/src/main/java/duelistmod/DuelistCardLibrary.java
+++ b/DuelistMod/src/main/java/duelistmod/DuelistCardLibrary.java
@@ -1111,7 +1111,7 @@ public class DuelistCardLibrary
 		DuelistMod.myCards.add(new HunterSpider());
 		DuelistMod.myCards.add(new NeoBug());
 		DuelistMod.myCards.add(new RazorLizard());
-		//DuelistMod.myCards.add(new TornadoDragon());
+		DuelistMod.myCards.add(new TornadoDragon());
 		DuelistMod.myCards.add(new AtomicFirefly());
 		DuelistMod.myCards.add(new CobraJar());
 		DuelistMod.myCards.add(new DarkSpider());

--- a/DuelistMod/src/main/java/duelistmod/actions/common/EvokeRandomOrbAction.java
+++ b/DuelistMod/src/main/java/duelistmod/actions/common/EvokeRandomOrbAction.java
@@ -1,0 +1,34 @@
+package duelistmod.actions.common;
+
+import com.megacrit.cardcrawl.actions.AbstractGameAction;
+import com.megacrit.cardcrawl.characters.AbstractPlayer;
+import com.megacrit.cardcrawl.core.Settings;
+import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
+import com.megacrit.cardcrawl.orbs.AbstractOrb;
+import com.megacrit.cardcrawl.orbs.EmptyOrbSlot;
+import duelistmod.helpers.Util;
+
+import java.util.ArrayList;
+
+public class EvokeRandomOrbAction extends AbstractGameAction {
+    public EvokeRandomOrbAction() {
+        target = AbstractDungeon.player;
+        actionType = ActionType.DAMAGE;
+        duration = Settings.ACTION_DUR_FAST;
+    }
+
+    @Override
+    public void update()
+    {
+        ArrayList<AbstractOrb> orbs = new ArrayList<AbstractOrb>();
+        for (AbstractOrb o : AbstractDungeon.player.orbs) { if (!(o instanceof EmptyOrbSlot)) { orbs.add(o); }}
+        if (orbs.size() > 0) {
+            int index = AbstractDungeon.cardRandomRng.random(0, orbs.size() - 1);
+            Util.log("EvokeRandomOrbAction is evoking at index " + index);
+            AbstractOrb toEvoke = orbs.get(index);
+            Util.log("EvokeRandomOrbAction is evoking orb " + toEvoke.name);
+            addToTop(new EvokeSpecificOrbAction(toEvoke, 1));
+        }
+        this.isDone = true;
+    }
+}

--- a/DuelistMod/src/main/java/duelistmod/cards/pools/insects/TornadoDragon.java
+++ b/DuelistMod/src/main/java/duelistmod/cards/pools/insects/TornadoDragon.java
@@ -13,6 +13,7 @@ import com.megacrit.cardcrawl.orbs.*;
 
 import duelistmod.DuelistMod;
 import duelistmod.abstracts.DuelistCard;
+import duelistmod.actions.common.EvokeRandomOrbAction;
 import duelistmod.actions.common.EvokeSpecificOrbAction;
 import duelistmod.helpers.Util;
 import duelistmod.patches.AbstractCardEnum;
@@ -56,30 +57,18 @@ public class TornadoDragon extends DuelistCard
     	summon();
     	if (p.hasOrb())
     	{
-    		ArrayList<AbstractOrb> orbs = new ArrayList<AbstractOrb>();
-    		for (AbstractOrb o : p.orbs) { if (!(o instanceof EmptyOrbSlot)) { orbs.add(o); }}
-    		if (orbs.size() > 0)
+    		int orbCount = 0;
+    		for (AbstractOrb o : p.orbs) { if (!(o instanceof EmptyOrbSlot)) { orbCount++; }}
+    		if (orbCount > 0)
     		{
-    			int orbsToEvoke = AbstractDungeon.cardRandomRng.random(0, orbs.size());
-    			if (orbsToEvoke == orbs.size()) { DuelistCard.evokeAll(); }
+    			int orbsToEvoke = AbstractDungeon.cardRandomRng.random(0, orbCount);
+    			Util.log("Tornado Dragon is evoking " + orbCount + " orbs.");
+    			if (orbsToEvoke == orbCount) { DuelistCard.evokeAll(); }
     			else if (orbsToEvoke > 0)
     			{
-    				ArrayList<Integer> indices = new ArrayList<>();
-    				Map<Integer, Integer> map = new HashMap<>();
-    				while (indices.size() < orbsToEvoke)
-    				{
-    					int newIndex = AbstractDungeon.cardRandomRng.random(0, orbs.size() - 1);
-    					while (map.containsKey(newIndex)) { newIndex = AbstractDungeon.cardRandomRng.random(0, orbs.size() - 1); }
-    					indices.add(newIndex);
-    					map.put(newIndex, 0);
-    				}
-    				
-    				for (Integer i : indices)
-    				{
-    					AbstractOrb toEvoke = orbs.get(i);
-    					this.addToBot(new EvokeSpecificOrbAction(toEvoke, 1)); 
-    					Util.log("Tornado Dragon is evoking " + toEvoke.name);
-    				}
+    				for (int i=0; i<orbsToEvoke; i++) {
+    					this.addToBot(new EvokeRandomOrbAction());
+					}
     			}
     			else { Util.log("Tornado Dragon generated 0 for number of orbs to evoke! Discarding promptly! :)"); }
     		}


### PR DESCRIPTION
Change Tornado Dragon to call the new EvokeRandomOrbAction instead of
evoking the orbs manually, causing potential out of bounds errors.