### PR TITLE
Optimize DynamicDamageCard

### DIFF
--- a/src/main/java/duelistmod/abstracts/DynamicDamageCard.java
+++ b/src/main/java/duelistmod/abstracts/DynamicDamageCard.java
@@ -33,8 +33,7 @@ public abstract class DynamicDamageCard extends DuelistCard {
         int standardVal = (this.originalDamage + this.damageFunction()) * this.damageFunctionMultiplier();
         this.damage = this.baseDamage = standardVal;
         super.applyPowers();
-        int diff = this.damage - standardVal;
-        this.damage = ((this.originalDamage + this.damageFunction()) * this.damageFunctionMultiplier()) + diff + this.extraFinalDamage();
+        this.damage += this.extraFinalDamage();
         this.isDamageModified = this.damage != standardVal;
         this.initializeDescription();
     }
@@ -44,8 +43,7 @@ public abstract class DynamicDamageCard extends DuelistCard {
         int standardVal = (this.originalDamage + this.damageFunction()) * this.damageFunctionMultiplier();
         this.damage = this.baseDamage = standardVal;
         super.calculateCardDamage(mo);
-        int diff = this.damage - standardVal;
-        this.damage = ((this.originalDamage + this.damageFunction()) * this.damageFunctionMultiplier()) + diff + this.extraFinalDamage();
+        this.damage += this.extraFinalDamage();
         this.isDamageModified = this.damage != standardVal;
         this.initializeDescription();
     }


### PR DESCRIPTION
There is no reason to have to call damageFunction twice in such a redundant manner.