### PR TITLE
Refactor Armed Dragon Level Up code

### DIFF
--- a/src/main/java/duelistmod/abstracts/ArmedDragonCard.java
+++ b/src/main/java/duelistmod/abstracts/ArmedDragonCard.java
@@ -3,11 +3,9 @@ package duelistmod.abstracts;
 import com.badlogic.gdx.graphics.Color;
 import com.megacrit.cardcrawl.actions.common.MakeTempCardInDiscardAction;
 import com.megacrit.cardcrawl.cards.AbstractCard;
-import com.megacrit.cardcrawl.characters.AbstractPlayer;
 import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
-import com.megacrit.cardcrawl.monsters.AbstractMonster;
 
-import duelistmod.cards.pools.dragons.*;
+import java.util.ArrayList;
 
 public abstract class ArmedDragonCard extends DuelistCard {
 
@@ -15,236 +13,72 @@ public abstract class ArmedDragonCard extends DuelistCard {
 			CardColor COLOR, CardRarity RARITY, CardTarget TARGET) {
 		super(ID, NAME, IMG, COST, DESCRIPTION, TYPE, COLOR, RARITY, TARGET);
 	}
-	
+
+	public abstract AbstractCard nextLevel();
 	
 	public static void armedProtectorLvlUp()
 	{
-		lvlUpDraw();
-		lvlUpDiscard();
-		lvlUpExhaust();
+		lvlUpGroup(AbstractDungeon.player.hand.group);
+		lvlUpGroup(AbstractDungeon.player.discardPile.group);
+		lvlUpGroup(AbstractDungeon.player.exhaustPile.group);
 		lvlUpHand();
 	}
 
-	public static void lvlUpDraw()
+	public static void lvlUpGroup(ArrayList<AbstractCard> group)
 	{
-		for (int i = 0; i < AbstractDungeon.player.drawPile.group.size(); i++)
+		for (int i = 0; i < group.size(); i++)
 		{
-			AbstractCard current = AbstractDungeon.player.drawPile.group.get(i);
-			if (current instanceof ArmedDragon3)
+			AbstractCard current = group.get(i);
+			if (current instanceof ArmedDragonCard)
 			{
-				AbstractCard target = current;
-				boolean upgrade = target.upgraded;
-				AbstractCard ad5 = new ArmedDragon5();
-				if (upgrade) { ad5.upgrade(); }
-	            AbstractDungeon.player.drawPile.group.set(i, ad5);
-			}
-			
-			else if (current instanceof ArmedDragon5)
-			{
-				AbstractCard target = current;
-				boolean upgrade = target.upgraded;
-				AbstractCard ad5 = new ArmedDragon7();
-				if (upgrade) { ad5.upgrade(); }
-	            AbstractDungeon.player.drawPile.group.set(i, ad5);
-			}
-			
-			else if (current instanceof ArmedDragon7)
-			{
-				AbstractCard target = current;
-				boolean upgrade = target.upgraded;
-				AbstractCard ad5 = new ArmedDragon10();
-				if (upgrade) { ad5.upgrade(); }
-	            AbstractDungeon.player.drawPile.group.set(i, ad5);
-			}
-			else if (current instanceof ArmedDragon10)
-			{
-				current.upgrade();
+				AbstractCard next = ((ArmedDragonCard) current).nextLevel();
+				if (next != null)
+				{
+					group.set(i, next);
+				}
+				else // Card is already at the highest level
+				{
+					current.upgrade();
+				}
 			}
 		}
 	}
-	
-	public static void lvlUpDiscard()
-	{
-		for (int i = 0; i < AbstractDungeon.player.discardPile.group.size(); i++)
-		{
-			AbstractCard current = AbstractDungeon.player.discardPile.group.get(i);
-			if (current instanceof ArmedDragon3)
-			{
-				AbstractCard target = current;
-				boolean upgrade = target.upgraded;
-				AbstractCard ad5 = new ArmedDragon5();
-				if (upgrade) { ad5.upgrade(); }
-	            AbstractDungeon.player.discardPile.group.set(i, ad5);
-			}
-			
-			else if (current instanceof ArmedDragon5)
-			{
-				AbstractCard target = current;
-				boolean upgrade = target.upgraded;
-				AbstractCard ad5 = new ArmedDragon7();
-				if (upgrade) { ad5.upgrade(); }
-	            AbstractDungeon.player.discardPile.group.set(i, ad5);
-			}
-			
-			else if (current instanceof ArmedDragon7)
-			{
-				AbstractCard target = current;
-				boolean upgrade = target.upgraded;
-				AbstractCard ad5 = new ArmedDragon10();
-				if (upgrade) { ad5.upgrade(); }
-	            AbstractDungeon.player.discardPile.group.set(i, ad5);
-			}
-			else if (current instanceof ArmedDragon10)
-			{
-				current.upgrade();
-			}
-		}
-	}
-	
+
 	public static void lvlUpHand()
 	{
 		for (int i = 0; i < AbstractDungeon.player.hand.group.size(); i++)
 		{
 			AbstractCard current = AbstractDungeon.player.hand.group.get(i);
-			if (current instanceof ArmedDragon3)
+			if (current instanceof ArmedDragonCard)
 			{
-				AbstractCard target = current;
-				boolean upgrade = target.upgraded;
-				AbstractCard ad5 = new ArmedDragon5();
-				if (upgrade) { ad5.upgrade(); }
-	            ad5.current_x = target.current_x;
-	            ad5.current_y = target.current_y;
-	            ad5.target_x = target.target_x;
-	            ad5.target_y = target.target_y;
-	            ad5.drawScale = 1.0f;
-	            ad5.targetDrawScale = target.targetDrawScale;
-	            ad5.angle = target.angle;
-	            ad5.targetAngle = target.targetAngle;
-	            ad5.superFlash(Color.WHITE.cpy());
-	            AbstractDungeon.player.hand.group.set(i, ad5);
-	            AbstractDungeon.player.hand.glowCheck();
-			}
-			
-			else if (current instanceof ArmedDragon5)
-			{
-				AbstractCard target = current;
-				boolean upgrade = target.upgraded;
-				AbstractCard ad5 = new ArmedDragon7();
-				if (upgrade) { ad5.upgrade(); }
-	            ad5.current_x = target.current_x;
-	            ad5.current_y = target.current_y;
-	            ad5.target_x = target.target_x;
-	            ad5.target_y = target.target_y;
-	            ad5.drawScale = 1.0f;
-	            ad5.targetDrawScale = target.targetDrawScale;
-	            ad5.angle = target.angle;
-	            ad5.targetAngle = target.targetAngle;
-	            ad5.superFlash(Color.WHITE.cpy());
-	            AbstractDungeon.player.hand.group.set(i, ad5);
-	            AbstractDungeon.player.hand.glowCheck();
-			}
-			
-			else if (current instanceof ArmedDragon7)
-			{
-				AbstractCard target = current;
-				boolean upgrade = target.upgraded;
-				AbstractCard ad5 = new ArmedDragon10();
-				if (upgrade) { ad5.upgrade(); }
-	            ad5.current_x = target.current_x;
-	            ad5.current_y = target.current_y;
-	            ad5.target_x = target.target_x;
-	            ad5.target_y = target.target_y;
-	            ad5.drawScale = 1.0f;
-	            ad5.targetDrawScale = target.targetDrawScale;
-	            ad5.angle = target.angle;
-	            ad5.targetAngle = target.targetAngle;
-	            ad5.superFlash(Color.WHITE.cpy());
-	            AbstractDungeon.player.hand.group.set(i, ad5);
-	            AbstractDungeon.player.hand.glowCheck();
-			}
-			else if (current instanceof ArmedDragon10)
-			{
-				current.upgrade();
-			}
-		}
-	}
-	
-	public static void lvlUpExhaust()
-	{
-		for (int i = 0; i < AbstractDungeon.player.exhaustPile.group.size(); i++)
-		{
-			AbstractCard current = AbstractDungeon.player.exhaustPile.group.get(i);
-			if (current instanceof ArmedDragon3)
-			{
-				AbstractCard target = current;
-				boolean upgrade = target.upgraded;
-				AbstractCard ad5 = new ArmedDragon5();
-				if (upgrade) { ad5.upgrade(); }
-	            AbstractDungeon.player.exhaustPile.group.set(i, ad5);
-			}
-			
-			else if (current instanceof ArmedDragon5)
-			{
-				AbstractCard target = current;
-				boolean upgrade = target.upgraded;
-				AbstractCard ad5 = new ArmedDragon7();
-				if (upgrade) { ad5.upgrade(); }
-	            AbstractDungeon.player.exhaustPile.group.set(i, ad5);
-			}
-			
-			else if (current instanceof ArmedDragon7)
-			{
-				AbstractCard target = current;
-				boolean upgrade = target.upgraded;
-				AbstractCard ad5 = new ArmedDragon10();
-				if (upgrade) { ad5.upgrade(); }
-	            AbstractDungeon.player.exhaustPile.group.set(i, ad5);
-			}
-			else if (current instanceof ArmedDragon10)
-			{
-				current.upgrade();
+				AbstractCard next = ((ArmedDragonCard) current).nextLevel();
+				if (next != null)
+				{
+					next.current_x = current.current_x;
+					next.current_y = current.current_y;
+					next.target_x = current.target_x;
+					next.target_y = current.target_y;
+					next.drawScale = 1.0f;
+					next.targetDrawScale = current.targetDrawScale;
+					next.angle = current.angle;
+					next.targetAngle = current.targetAngle;
+					next.superFlash(Color.WHITE.cpy());
+					AbstractDungeon.player.hand.group.set(i, next);
+					AbstractDungeon.player.hand.glowCheck();
+				}
+				else // Card is already at the highest level
+				{
+					current.upgrade();
+				}
 			}
 		}
 	}
 	
 	public void lvlUpNoExhaust()
 	{
-		if (this instanceof ArmedDragon5)
-		{		
-			AbstractCard ad = new ArmedDragon7();
-			if (this.upgraded) { ad.upgrade(); }
-			//this.addToBot(new WaitAction(1.0f));
-			this.addToBot(new MakeTempCardInDiscardAction(ad, 1));
-		}
-		else if (this instanceof ArmedDragon7)
-		{		
-			AbstractCard ad = new ArmedDragon10();
-			if (this.upgraded) { ad.upgrade(); }
-			//this.addToBot(new WaitAction(1.0f));
-			this.addToBot(new MakeTempCardInDiscardAction(ad, 1));
+		AbstractCard ad = nextLevel();
+		if (ad != null) {
+			addToBot(new MakeTempCardInDiscardAction(ad, 1));
 		}
 	}
-
-
-
-	
-
-	
-
-
-
-
-
-	@Override
-	public void upgrade() {
-		// TODO Auto-generated method stub
-
-	}
-
-	@Override
-	public void use(AbstractPlayer arg0, AbstractMonster arg1) {
-		// TODO Auto-generated method stub
-
-	}
-
 }

--- a/src/main/java/duelistmod/cards/pools/dragons/ArmedDragon10.java
+++ b/src/main/java/duelistmod/cards/pools/dragons/ArmedDragon10.java
@@ -62,6 +62,11 @@ public class ArmedDragon10 extends ArmedDragonCard
         return new ArmedDragon10();
     }
 
+    @Override
+    public AbstractCard nextLevel() {
+        return null;
+    }
+
     // Upgraded stats.
     @Override
     public void upgrade() {

--- a/src/main/java/duelistmod/cards/pools/dragons/ArmedDragon3.java
+++ b/src/main/java/duelistmod/cards/pools/dragons/ArmedDragon3.java
@@ -74,6 +74,15 @@ public class ArmedDragon3 extends ArmedDragonCard
         return new ArmedDragon3();
     }
 
+    @Override
+    public AbstractCard nextLevel() {
+        AbstractCard next = new ArmedDragon5();
+        if (upgraded) {
+            next.upgrade();
+        }
+        return next;
+    }
+
     // Upgraded stats.
     @Override
     public void upgrade() {

--- a/src/main/java/duelistmod/cards/pools/dragons/ArmedDragon5.java
+++ b/src/main/java/duelistmod/cards/pools/dragons/ArmedDragon5.java
@@ -76,6 +76,15 @@ public class ArmedDragon5 extends ArmedDragonCard
         return new ArmedDragon5();
     }
 
+    @Override
+    public AbstractCard nextLevel() {
+        AbstractCard next = new ArmedDragon7();
+        if (upgraded) {
+            next.upgrade();
+        }
+        return next;
+    }
+
     // Upgraded stats.
     @Override
     public void upgrade() {

--- a/src/main/java/duelistmod/cards/pools/dragons/ArmedDragon7.java
+++ b/src/main/java/duelistmod/cards/pools/dragons/ArmedDragon7.java
@@ -74,6 +74,15 @@ public class ArmedDragon7 extends ArmedDragonCard
         return new ArmedDragon7();
     }
 
+    @Override
+    public AbstractCard nextLevel() {
+        AbstractCard next = new ArmedDragon7();
+        if (upgraded) {
+            next.upgrade();
+        }
+        return next;
+    }
+
     // Upgraded stats.
     @Override
     public void upgrade() {

--- a/src/main/resources/duelistModResources/localization/eng/DuelistMod-Card-Strings.json
+++ b/src/main/resources/duelistModResources/localization/eng/DuelistMod-Card-Strings.json
@@ -6142,14 +6142,14 @@
 		"UPGRADE_DESCRIPTION": "Dragon NL Summon !duelist:SUMM! NL Gain !B! Block. NL If you have no Spells in your hand, add a copy of this to your hand. NL Exhaust."
 	},
 	"theDuelist:ArmedDragon5": {
-		"DESCRIPTION": "Dragon NL Tribute !duelist:TRIB! NL Summon !duelist:SUMM! NL Deal !D! damage. NL If you Tribute Armed Dragon LV3, Level Up.",
+		"DESCRIPTION": "Dragon NL Tribute !duelist:TRIB! NL Summon !duelist:SUMM! NL Deal !D! damage. NL If you Tribute Armed Dragon LV3, Level_Up.",
 		"NAME": "Armed Dragon LV5",
-		"UPGRADE_DESCRIPTION": "Dragon NL Tribute !duelist:TRIB! NL Summon !duelist:SUMM! NL Deal !D! damage. NL If you Tribute Armed Dragon LV3, Level Up."
+		"UPGRADE_DESCRIPTION": "Dragon NL Tribute !duelist:TRIB! NL Summon !duelist:SUMM! NL Deal !D! damage. NL If you Tribute Armed Dragon LV3, Level_Up."
 	},
 	"theDuelist:ArmedDragon7": {
-		"DESCRIPTION": "Dragon NL Tribute !duelist:TRIB! NL Deal !D! damage twice. NL If you Tribute Armed Dragon LV5, Level Up. NL Exempt.",
+		"DESCRIPTION": "Dragon NL Tribute !duelist:TRIB! NL Deal !D! damage twice. NL If you Tribute Armed Dragon LV5, Level_Up. NL Exempt.",
 		"NAME": "Armed Dragon LV7",
-		"UPGRADE_DESCRIPTION": "Dragon NL Tribute !duelist:TRIB! NL Deal !D! damage twice. NL If you Tribute Armed Dragon LV5, Level Up. NL Exempt."
+		"UPGRADE_DESCRIPTION": "Dragon NL Tribute !duelist:TRIB! NL Deal !D! damage twice. NL If you Tribute Armed Dragon LV5, Level_Up. NL Exempt."
 	},
 	"theDuelist:ArmedDragon10": {
 		"DESCRIPTION": "Dragon NL Tribute !duelist:TRIB! NL Deal !D! damage to ALL enemies. NL Exempt.",
@@ -6157,9 +6157,9 @@
 		"UPGRADE_DESCRIPTION": "Dragon NL Tribute !duelist:TRIB! NL Deal !D! damage to ALL enemies. NL Exempt."
 	},
 	"theDuelist:ArmedProtectorDragon": {
-		"DESCRIPTION": "Dragon NL Tribute !duelist:TRIB! NL Level up all *Armed Dragons (everywhere).",
+		"DESCRIPTION": "Dragon NL Tribute !duelist:TRIB! NL Level_Up ALL *Armed Dragons (everywhere).",
 		"NAME": "Armed Protect Dragon",
-		"UPGRADE_DESCRIPTION": "Innate NL Dragon NL Tribute !duelist:TRIB! NL Level up all *Armed Dragons (everywhere)."
+		"UPGRADE_DESCRIPTION": "Innate NL Dragon NL Tribute !duelist:TRIB! NL Level Up ALL *Armed Dragons (everywhere)."
 	},
 	"theDuelist:AtomicScrapDragon": {
 		"DESCRIPTION": "Machine Dragon NL Tribute !duelist:TRIB! NL Deal !D! damage. NL Costs !M! less Tribute for each card in your hand with a modified Tribute cost.",

--- a/src/main/resources/duelistModResources/localization/eng/DuelistMod-Keyword-Strings.json
+++ b/src/main/resources/duelistModResources/localization/eng/DuelistMod-Keyword-Strings.json
@@ -1141,6 +1141,18 @@
     "DESCRIPTION": "At the end of your turn, #yTribute ALL #yGusto monsters that are not #ySpellcasters. NL When you #yTribute a #yGusto monster, gain #b1 #yBlock."
   },
   {
+    "PROPER_NAME": "Level Up",
+    "NAMES": [
+      "Level Up",
+      "level up",
+      "Level_Up"
+    ],
+    "DESCRIPTION": "Changes card to the next #yLV for this combat.",
+    "MULTIWORD_KEY": "Level_Up",
+    "FORMATTED_DISPLAY": "*Level *Up",
+    "BASE_KEYWORD": "level up"
+  },
+  {
     "PROPER_NAME": "Special Summon",
     "NAMES": [
       "Special Summon",


### PR DESCRIPTION
Move the logic for deciding what to level up an Armed Dragon to so it's handled by the cards themselves instead of the parent class.

This should make the level up system easier to expand if desired.

Also changed Level Up to a keyword.